### PR TITLE
Fix README lesson path

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ It’s not a textbook – it’s a trajectory.
 2. Navigate to a lesson:
    
    ```bash
-   cd PCS-CSS/L1_CSS SELECTORS
+   cd "PCS-CSS/L1 CSS_selectors"
 
 3. Open index.html in your browser and enjoy the ride.
 


### PR DESCRIPTION
## Summary
- fix the lesson path in the README navigation example

## Testing
- `tidy -q -e 'L1 CSS_selectors/CSS Selectors.html'`
- `tidy -q -e 'L2 CSS_vars_text/CSS Variables.html'`
- `tidy -q -e 'L3 CSS_sizing/CSS Sizing.html'`


------
https://chatgpt.com/codex/tasks/task_e_6873cb08a00c832ea74c85b1692c7e4d